### PR TITLE
Changed the example config to use the options argument for the base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
         options: {
           port: 9001,
           middleware: function(connect, options) {
-            return [lrSnippet, folderMount(connect, '.')]
+            return [lrSnippet, folderMount(connect, options.base)]
           }
         }
       }


### PR DESCRIPTION
In the example config, the middleware gets passed the options argument, but isn't being used. It simply sets the base path to '.'

I changed it so it uses options.base which defaults to '.', but allows a user to use the `base` option in the connect settings.
