### PR TITLE
Set Content-Length correctly for multi byte files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     }
 
     if (!this.headerSent) {
-      this.setHeader('content-length', body.length);
+      this.setHeader('content-length', Buffer.byteLength(body));
       this._implicitHeader();
     }
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -48,6 +48,41 @@ describe('livereloadSnippet', function () {
     assert.ok(implicitHeaderCalled);
   });
 
+  it('should send correct content-length for html containing multi byte', function(done) {
+    var req = { url: '/' };
+    var headers = {};
+    var implicitHeaderCalled = false;
+    var writeString = '';
+    var res = {
+      socket: {
+        server: {
+          address: function () {
+            return {
+              port: 12345
+            };
+          }
+        }
+      },
+      write: function (string) {
+        writeString = string;
+      },
+      setHeader: function (header, value) {
+        headers[header] = value;
+      },
+      _implicitHeader: function () {
+        implicitHeaderCalled = true;
+      }
+    };
+    var next = function () {
+      done();
+    };
+    utils.livereloadSnippet(req, res, next);
+    res.write('<h1>Foo</h1><p>Multibyte characters here: ääää ööööö åååååå</p><p>Some html here</p>');
+    // original write is called
+    assert.equal(headers['content-length'], 99);
+    assert.ok(implicitHeaderCalled);
+  });
+
   it('should do nothing if requested page is not an HTML page', function (done) {
     var req = { url: '/favicon.ico' };
     var writeString = '';


### PR DESCRIPTION
When inserting (or not inserting) the snippet for html files
containing multi byte characters, the content-length should
be calculated using Buffer.byteLength instead of string-length

This is the ground reason for issue yeoman/generator-webapp#13
