### PR TITLE
Strip query params in LR snippet middleware

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 var Server = require('tiny-lr');
 var path = require('path');
+var url = require('url');
 
 var utils = module.exports;
 
@@ -60,7 +61,9 @@ var getSnippet = function () {
 
 utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
   var write = res.write;
-  var filepath = req.url.slice(-1) === '/' ? req.url + 'index.html' : req.url;
+
+  var filepath = url.parse(req.url).pathname;
+  filepath = filepath.slice(-1) === '/' ? filepath + 'index.html' : filepath;
 
   if (path.extname( filepath ) !== '.html') {
     return next();


### PR DESCRIPTION
The LR snippet middleware fails to match "index.html" if there are query params as well.

I've updated it to resolve that.
