### PR TITLE
Pass response encoding to calculate Content-Length correctly.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,7 +83,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     }
 
     if (!this.headerSent) {
-      this.setHeader('content-length', Buffer.byteLength(body));
+      this.setHeader('content-length', Buffer.byteLength(body, encoding));
       this._implicitHeader();
     }
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -41,10 +41,10 @@ describe('livereloadSnippet', function () {
       done();
     };
     utils.livereloadSnippet(req, res, next);
-    res.write('<body></body>');
+    res.write('<body>我能吞下玻璃而不伤身体。</body>','ascii');
     // original write is called
     assert.ok(writeString.match(/livereload snippet/));
-    assert.equal(headers['content-length'], 194);
+    assert.equal(headers['content-length'], 206);
     assert.ok(implicitHeaderCalled);
   });
 


### PR DESCRIPTION
When `livereloadSnippet` calculates the response's body length, encoding isn't being passed and occasionally leads to truncated responses.
