### PR TITLE
utils.livereloadSnippet should re-write Response.end() instead of Response.write()?

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ var getSnippet = function () {
 // }
 
 utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
-  var write = res.write;
+  var end = res.end;
 
   var filepath = url.parse(req.url).pathname;
   filepath = filepath.slice(-1) === '/' ? filepath + 'index.html' : filepath;
@@ -69,7 +69,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     return next();
   }
 
-  res.write = function (string, encoding) {
+  res.end = function (string, encoding) {
     var body = string instanceof Buffer ? string.toString() : string;
 
     body = body.replace(/<\/body>/, function (w) {
@@ -82,12 +82,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
       string = body;
     }
 
-    if (!this.headerSent) {
-      this.setHeader('content-length', Buffer.byteLength(body, encoding));
-      this._implicitHeader();
-    }
-
-    write.call(res, string, encoding);
+    end.call(res, string, encoding);
   };
 
   next();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,35 @@ var getSnippet = function () {
 // }
 
 utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
-  var end = res.end;
+  var send = res.send;
+
+  res.send = function (body) {
+
+    var args = [];
+
+    // allow status / body
+    if (2 === arguments.length) {
+      if ('number' !== typeof body && 'number' === typeof arguments[1]) {
+        this.statusCode = arguments[1];
+      } else {
+        this.statusCode = body;
+        body = arguments[1];
+      }
+      args.push(this.statusCode);
+    }
+
+    if ('string' === typeof body && body.length > 0) {
+      args.push(body.replace(/<\/body>/, function (w) {
+        return getSnippet() + w;
+      }));
+    } else {
+      args.push(body);
+    }
+
+    send.apply(res, args);
+  };
+
+  var write = res.write;
 
   var filepath = url.parse(req.url).pathname;
   filepath = filepath.slice(-1) === '/' ? filepath + 'index.html' : filepath;
@@ -69,7 +97,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     return next();
   }
 
-  res.end = function (string, encoding) {
+  res.write = function (string, encoding) {
     var body = string instanceof Buffer ? string.toString() : string;
 
     body = body.replace(/<\/body>/, function (w) {
@@ -82,7 +110,12 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
       string = body;
     }
 
-    end.call(res, string, encoding);
+    if (!this.headerSent) {
+      this.setHeader('content-length', Buffer.byteLength(body, encoding));
+      this._implicitHeader();
+    }
+
+    write.call(res, string, encoding);
   };
 
   next();

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,10 +12,8 @@ describe('livereloadSnippet', function () {
     utils.livereloadSnippet(req, res, next);
   });
 
-  it('should re-write response write function', function (done) {
+  it('should re-write response end function', function (done) {
     var req = { url: '/' };
-    var headers = {};
-    var implicitHeaderCalled = false;
     var writeString = '';
     var res = {
       socket: {
@@ -27,60 +25,17 @@ describe('livereloadSnippet', function () {
           }
         }
       },
-      write: function (string) {
+      end: function (string) {
         writeString = string;
-      },
-      setHeader: function (header, value) {
-        headers[header] = value;
-      },
-      _implicitHeader: function () {
-        implicitHeaderCalled = true;
       }
     };
     var next = function () {
       done();
     };
     utils.livereloadSnippet(req, res, next);
-    res.write('<body>我能吞下玻璃而不伤身体。</body>','ascii');
+    res.end('<body>我能吞下玻璃而不伤身体。</body>','ascii');
     // original write is called
     assert.ok(writeString.match(/livereload snippet/));
-    assert.equal(headers['content-length'], 206);
-    assert.ok(implicitHeaderCalled);
-  });
-
-  it('should send correct content-length for html containing multi byte', function(done) {
-    var req = { url: '/' };
-    var headers = {};
-    var implicitHeaderCalled = false;
-    var writeString = '';
-    var res = {
-      socket: {
-        server: {
-          address: function () {
-            return {
-              port: 12345
-            };
-          }
-        }
-      },
-      write: function (string) {
-        writeString = string;
-      },
-      setHeader: function (header, value) {
-        headers[header] = value;
-      },
-      _implicitHeader: function () {
-        implicitHeaderCalled = true;
-      }
-    };
-    var next = function () {
-      done();
-    };
-    utils.livereloadSnippet(req, res, next);
-    res.write('<h1>Foo</h1><p>Multibyte characters here: ääää ööööö åååååå</p><p>Some html here</p>');
-    // original write is called
-    assert.equal(headers['content-length'], 99);
-    assert.ok(implicitHeaderCalled);
   });
 
   it('should do nothing if requested page is not an HTML page', function (done) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,8 +12,10 @@ describe('livereloadSnippet', function () {
     utils.livereloadSnippet(req, res, next);
   });
 
-  it('should re-write response end function', function (done) {
+  it('should re-write response write function', function (done) {
     var req = { url: '/' };
+    var headers = {};
+    var implicitHeaderCalled = false;
     var writeString = '';
     var res = {
       socket: {
@@ -25,17 +27,60 @@ describe('livereloadSnippet', function () {
           }
         }
       },
-      end: function (string) {
+      write: function (string) {
         writeString = string;
+      },
+      setHeader: function (header, value) {
+        headers[header] = value;
+      },
+      _implicitHeader: function () {
+        implicitHeaderCalled = true;
       }
     };
     var next = function () {
       done();
     };
     utils.livereloadSnippet(req, res, next);
-    res.end('<body>我能吞下玻璃而不伤身体。</body>','ascii');
+    res.write('<body>我能吞下玻璃而不伤身体。</body>','ascii');
     // original write is called
     assert.ok(writeString.match(/livereload snippet/));
+    assert.equal(headers['content-length'], 206);
+    assert.ok(implicitHeaderCalled);
+  });
+
+  it('should send correct content-length for html containing multi byte', function(done) {
+    var req = { url: '/' };
+    var headers = {};
+    var implicitHeaderCalled = false;
+    var writeString = '';
+    var res = {
+      socket: {
+        server: {
+          address: function () {
+            return {
+              port: 12345
+            };
+          }
+        }
+      },
+      write: function (string) {
+        writeString = string;
+      },
+      setHeader: function (header, value) {
+        headers[header] = value;
+      },
+      _implicitHeader: function () {
+        implicitHeaderCalled = true;
+      }
+    };
+    var next = function () {
+      done();
+    };
+    utils.livereloadSnippet(req, res, next);
+    res.write('<h1>Foo</h1><p>Multibyte characters here: ääää ööööö åååååå</p><p>Some html here</p>');
+    // original write is called
+    assert.equal(headers['content-length'], 99);
+    assert.ok(implicitHeaderCalled);
   });
 
   it('should do nothing if requested page is not an HTML page', function (done) {
@@ -52,5 +97,64 @@ describe('livereloadSnippet', function () {
     utils.livereloadSnippet(req, res, next);
     res.write('fred');
     assert.equal('fred', writeString);
+  });
+
+  it('should re-write response send function', function (done) {
+    var req = { url: '/' };
+    var sendBody = '';
+    var res = {
+      send: function (body) {
+        sendBody = body;
+      }
+    };
+    var next = function () {
+      done();
+    };
+    utils.livereloadSnippet(req, res, next);
+    res.send('<body>我能吞下玻璃而不伤身体。</body>');
+    // original send is called
+    assert.ok(sendBody.match(/livereload snippet/));
+  });
+
+  it('should do nothing if sending just the http status code', function (done) {
+    var req = { url: '/' };
+    var statusCode = -1;
+    var res = {
+      send: function (body) {
+        statusCode = body;
+      }
+    };
+    var next = function () {
+      done();
+    };
+    utils.livereloadSnippet(req, res, next);
+    res.send(200);
+    assert.equal(200, statusCode);
+  });
+
+  it('should support optional status code as first or second argument when doing res.send()', function (done) {
+    var req = { url: '/' };
+    var statusCode = -1;
+    var sendBody = '';
+    var res = {
+      send: function (body) {
+        statusCode = body;
+        sendBody = arguments[1];
+      }
+    };
+    var next = function() {
+      done();
+    };
+    utils.livereloadSnippet(req, res, next);
+    res.send(200, '<body>hello</body>');
+    assert.ok(sendBody.match(/livereload snippet/));
+    assert.equal(200, statusCode);
+
+    // resetting for case 2
+    statusCode = -1;
+    sendBody = '';
+    res.send('<body>hello</body>', 200);
+    assert.ok(sendBody.match(/livereload snippet/));
+    assert.equal(200, statusCode);
   });
 });


### PR DESCRIPTION
The utils.livereloadSnippet would not work for cases when Response.write() was called with [this condition](https://github.com/joyent/node/blob/master/lib/http.js#L843). See node source https://github.com/joyent/node/blob/master/lib/http.js#L863 and https://github.com/joyent/node/blob/master/lib/http.js#L919. When end() is used to send out the final response, it sometimes use `this.connection.write` instead of `this.write()`.

I have not dig too deep into this, so I am not sure if this is the best way to do it. Maybe we need to check the [condition](https://github.com/joyent/node/blob/master/lib/http.js#L843) and re-write one of the two?
