### PR TITLE
Add ** to regarde task

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ module.exports = function (grunt) {
     },
     // Configuration to be run (and then tested)
     regarde: {
-      fred: {
-        files: '*.txt',
+      txt: {
+        files: '**/*.txt',
         tasks: ['livereload']
       }
     }


### PR DESCRIPTION
It isn't immediately obvious for a new user why the sample config doesn't work with nested files.
Using a more permissive match both makes it work and teaches the user that this type of matching exists. 

Thanks for the great task, btw!
