### PR TITLE
Public access to livereload script tag snippet

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ var getSnippet = function () {
   return snippet;
 };
 
-utils.livereloadScriptTag = function() {
+utils.livereloadScriptTag = function livereloadScriptTag() {
   return getSnippet();
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,6 +36,10 @@ var getSnippet = function () {
   return snippet;
 };
 
+utils.livereloadScriptTag = function() {
+  return getSnippet();
+};
+
 //
 // This function returns a connect middleware that will insert a snippet
 // of JavaScript needed to connect to the livereload server

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ utils.startLRServer = function startLRServer(grunt, done) {
   return _server;
 };
 
-var getSnippet = function () {
+utils.getSnippet = function () {
   /*jshint quotmark:false */
   var snippet = [
           "<!-- livereload snippet -->",
@@ -34,10 +34,6 @@ var getSnippet = function () {
           ""
           ].join('\n');
   return snippet;
-};
-
-utils.livereloadScriptTag = function livereloadScriptTag() {
-  return getSnippet();
 };
 
 //
@@ -77,7 +73,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     var body = string instanceof Buffer ? string.toString() : string;
 
     body = body.replace(/<\/body>/, function (w) {
-      return getSnippet() + w;
+      return utils.getSnippet() + w;
     });
 
     if (string instanceof Buffer) {


### PR DESCRIPTION
Hey there, 

it would be nice to reuse the livereload script tag snippet (see PR), to extend for instance the connect middleware with some custom functionality. In my case I would like to plugin a dispatcher for app routes to be served with my index.html: 

<pre><code>
var lrScriptTag = require('grunt-contrib-livereload/lib/utils').livereloadScriptTag;

middleware: function (connect, options) {
    var dispatch = require('dispatch');
    var routeDispatcher = function(req, res, next) {
                            
        var index = grunt.file.read(yeomanConfig.app + '/index.html');
        index = index.replace(/&lt;\/body&gt;/, function (w) {
          return lrScriptTag() + w;
        });
        res.write(index);
        res.end();
    }
    return [
        lrSnippet,
        mountFolder(connect, '.tmp'),
        mountFolder(connect, yeomanConfig.app),
        dispatch({
            '/([\\w\\/]+)': routeDispatcher
        })
    ];
}
</code></pre>


Or do you have any better solutions to solve my use case? thanks
