### PR TITLE
Adding a specific livereload config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ var folderMount = function folderMount(connect, point) {
 module.exports = function (grunt) {
   // Project configuration.
   grunt.initConfig({
+    livereload: {
+      port: 35729 // Default livereload listening port.
+    },
     connect: {
       livereload: {
         options: {


### PR DESCRIPTION
So this is a minor doc fix.

By looking at the readme, it's not clear that you need to add a "livereaload" config specifying the listening port in order to change the actual livereload port.

It's very easy to confused that port with the connect port :-/ 

At least it was for me.
