### PR TITLE
Fix long time livereload loading. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It will be inserted on the fly in your HTML and will connect back to the liverel
 
 ```html
 <!-- livereload snippet -->
-<script>document.write('<script src=\"http://'
+<script>document.write('<script async="" src=\"http://'
 + (location.host || 'localhost').split(':')[0]
 + ':" + port + "/livereload.js?snipver=1\"><\\/script>')
 </script>


### PR DESCRIPTION
Sometimes, I don't know why, livereload.js is really slow to load. As it's synchronised, it blocks all my other scripts and I can't work. So adding async="" is a (temporary) solution. It still work when it's loaded just after.
