### PR TITLE
Add a client port option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ It will be inserted on the fly in your HTML and will connect back to the liverel
 <!-- livereload snippet -->
 <script>document.write('<script src=\"http://'
 + (location.host || 'localhost').split(':')[0]
-+ ':" + port + "/livereload.js?snipver=1\"><\\/script>')
++ ':" + clientPort + "/livereload.js?snipver=1\"><\\/script>')
 </script>
 ```
 
@@ -73,6 +73,12 @@ Type: `integer`
 Default: `35729`
 
 The port the livereload server should listen on.
+
+#### clientPort
+Type: `integer`
+Default: `port`
+
+The port where livereload is accessible by the client. Can be useful behind a HTTP reverse proxy.
 
 #### Example config
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,8 @@ var url = require('url');
 
 var utils = module.exports;
 
-var port = 35729;
+var port = 35729,
+  clientPort = port;
 
 utils.startLRServer = function startLRServer(grunt, done) {
   var _ = grunt.util._;
@@ -19,6 +20,12 @@ utils.startLRServer = function startLRServer(grunt, done) {
   grunt.log.writeln('... Starting Livereload server on ' + options.port + ' ...');
   port = options.port;
 
+  if (options.clientPort) {
+    clientPort = options.clientPort;
+  } else {
+    clientPort = port;
+  }
+
   _server.listen(options.port, done);
   return _server;
 };
@@ -29,7 +36,7 @@ utils.getSnippet = function () {
           "<!-- livereload snippet -->",
           "<script>document.write('<script src=\"http://'",
           " + (location.host || 'localhost').split(':')[0]",
-          " + ':" + port + "/livereload.js?snipver=1\"><\\/script>')",
+          " + ':" + clientPort + "/livereload.js?snipver=1\"><\\/script>')",
           "</script>",
           ""
           ].join('\n');


### PR DESCRIPTION
I added an option for client side livereload port.

It's a solution to this issue : https://github.com/gruntjs/grunt-contrib-livereload/issues/34

I also make a change on tiny-lr for handling port 80 :
https://github.com/mklabs/tiny-lr/pull/10
