### PR TITLE
Add snippet even if there is no "</body>" in the html

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,9 +78,11 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
     if (string !== undefined) {
       var body = string instanceof Buffer ? string.toString(encoding) : string;
 
-      res.push(body.replace(/<\/body>/, function (w) {
-        return utils.getSnippet() + w;
-      }));
+      res.push(body.match(/<\/body>/)
+        ? body.replace(/<\/body>/, function (w) {
+          return getSnippet() + w;
+        })
+        : body + getSnippet());
     }
 
     return true;


### PR DESCRIPTION
I've simple webpage with no `<head>` or `<body>` since it's not required. This tiny update add the livereload snippet even if there is no body close tag.
