### PR TITLE
res.write not called, empty returned response

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,7 +102,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
         res.setHeader('content-length', Buffer.byteLength(res.data, encoding));
       }
 
-      write.call(res, res.data, encoding);
+      res.write = write;
       end.call(res, res.data, encoding);
     }
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,6 +59,7 @@ utils.getSnippet = function () {
 //   }
 // }
 utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
+  var write = res.write;
   var writeHead = res.writeHead;
   var end = res.end;
   var filepath = url.parse(req.url).pathname;
@@ -101,6 +102,7 @@ utils.livereloadSnippet = function livereloadSnippet(req, res, next) {
         res.setHeader('content-length', Buffer.byteLength(res.data, encoding));
       }
 
+      write.call(res, res.data, encoding);
       end.call(res, res.data, encoding);
     }
   };


### PR DESCRIPTION
When I try to use the livereloadSnippet middleware in my grunt-express app [as here](https://github.com/blai/grunt-express-example/blob/master/app/server.js#L22), I get an empty response on my routes.

Looking at the code, one comment says, before overwriting `res.write`:

``` javascript
  // Bypass write until end
  var inject = res.write = function (string, encoding) {
```

But the call to the original res.write doesn't seem to take place. If I cache the value and include it before a call to the original res.end, I get the response I'm looking for - the livereload snippet included at the end of the body.
