### PR TITLE
Redirect users to grunt-contrib-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# This plugin is out of date, [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) now has an [option](https://github.com/gruntjs/grunt-contrib-watch#optionslivereload) for livereload.
 # grunt-contrib-livereload [![Build Status](https://secure.travis-ci.org/gruntjs/grunt-contrib-livereload.png?branch=master)](http://travis-ci.org/gruntjs/grunt-contrib-livereload)
 
 > Reload assets live in the browser


### PR DESCRIPTION
I was using this plugin until I realized that grunt-contrib-watch now has livereload functionality.

I wanted to alert other grunt users to use watch instead of unnecessarily adding two tasks to their config.
