### PR TITLE
Accessing livereload via proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Default: `35729`
 
 The port the livereload server should listen on.
 
+#### proxyPort
+
+Type: `integer`
+Default: `null` (Defaults to using the same value as the `port` option).
+
+Which port the snippet link uses to reach the livereload server. Use this
+option if you are accessing the livereload server via a proxy.
+
+#### https
+
+Type: `boolean`
+Default: `false`
+
+Whether the snippet link should use HTTPS protocol.
+
+Note: The livereload server does not itself support HTTPS! Only use this option
+if you are accessing the livereload server via a HTTPS proxy.
+
 #### Example config
 
 ```javascript

--- a/docs/livereload-options.md
+++ b/docs/livereload-options.md
@@ -6,3 +6,21 @@ Type: `integer`
 Default: `35729`
 
 The port the livereload server should listen on.
+
+## proxyPort
+
+Type: `integer`
+Default: `null` (Defaults to using the same value as the `port` option).
+
+Which port the snippet link uses to reach the livereload server. Use this
+option if you are accessing the livereload server via a proxy.
+
+## https
+
+Type: `boolean`
+Default: `false`
+
+Whether the snippet link should use HTTPS protocol.
+
+Note: The livereload server does not itself support HTTPS! Only use this option
+if you are accessing the livereload server via a proxy.

--- a/docs/livereload-options.md
+++ b/docs/livereload-options.md
@@ -23,4 +23,4 @@ Default: `false`
 Whether the snippet link should use HTTPS protocol.
 
 Note: The livereload server does not itself support HTTPS! Only use this option
-if you are accessing the livereload server via a proxy.
+if you are accessing the livereload server via a HTTPS proxy.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,8 @@ utils.getSnippet = function () {
           "<!-- livereload snippet -->",
           "<script>document.write('<script src=\"http" + s + "://'",
           " + (location.host || 'localhost').split(':')[0]",
-          " + ':" + p + "/livereload.js?snipver=1\"><\\/script>')",
+          " + ':" + p + "/livereload.js?snipver=1&port=" + port + "\">",
+          " + '<\\/script>')",
           "</script>",
           ""
           ].join('\n');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,18 +6,24 @@ var url = require('url');
 var utils = module.exports;
 
 var port = 35729;
+var https = false;
+var proxyPort = null;
 
 utils.startLRServer = function startLRServer(grunt, done) {
   var _ = grunt.util._;
   var _server;
 
   var options = _.defaults(grunt.config('livereload') || {}, {
-    port: 35729
+    port: 35729,
+    https: false,
+    proxyPort: null
   });
 
   _server = new Server();
   grunt.log.writeln('... Starting Livereload server on ' + options.port + ' ...');
   port = options.port;
+  https = options.https;
+  proxyPort = options.proxyPort;
 
   _server.listen(options.port, done);
   return _server;
@@ -25,11 +31,13 @@ utils.startLRServer = function startLRServer(grunt, done) {
 
 utils.getSnippet = function () {
   /*jshint quotmark:false */
+  var s = https ? 's' : '';
+  var p = proxyPort ? proxyPort : port;
   var snippet = [
           "<!-- livereload snippet -->",
-          "<script>document.write('<script src=\"http://'",
+          "<script>document.write('<script src=\"http" + s + "://'",
           " + (location.host || 'localhost').split(':')[0]",
-          " + ':" + port + "/livereload.js?snipver=1\"><\\/script>')",
+          " + ':" + p + "/livereload.js?snipver=1\"><\\/script>')",
           "</script>",
           ""
           ].join('\n');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,7 +37,7 @@ utils.getSnippet = function () {
           "<!-- livereload snippet -->",
           "<script>document.write('<script src=\"http" + s + "://'",
           " + (location.host || 'localhost').split(':')[0]",
-          " + ':" + p + "/livereload.js?snipver=1&port=" + port + "\">",
+          " + ':" + p + "/livereload.js?snipver=1&port=" + port + "\">'",
           " + '<\\/script>')",
           "</script>",
           ""


### PR DESCRIPTION
This commit adds a couple options to make it easier to access the livereload server via a proxy. I'm doing development work on a separate virtual machine from where my actual dev environment lives, in order to test out HTTPS features. However, that prevents the livereload script from working properly, since the browser refuses to run a script from an insecure channel on a secure page.

The two options added by this patch let me use my HTTPS proxy to access the livereload server.
