### PR TITLE
support port "0" to assign a random port

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,10 +16,14 @@ utils.startLRServer = function startLRServer(grunt, done) {
   });
 
   _server = new Server();
-  grunt.log.writeln('... Starting Livereload server on ' + options.port + ' ...');
   port = options.port;
 
-  _server.listen(options.port, done);
+  _server.listen(options.port, function () {
+     var addr = this.address();
+     port = addr.port;
+     grunt.log.writeln('... Starting Livereload server on ' + port + ' ...');
+     done();
+  });
   return _server;
 };
 


### PR DESCRIPTION
Query the listening port then print in console and apply to snippet for middleware of grunt-contrib-connect.
