### PR TITLE
update port change not working problem

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@ utils.startLRServer = function startLRServer(grunt, done) {
   var _ = grunt.util._;
   var _server;
 
-  var options = _.defaults(grunt.config('livereload') || {}, {
+  var options = _.defaults(grunt.config('connect').livereload || {}, {
     port: 35729
   });
 


### PR DESCRIPTION
update: port change not working for livereload config on gruntfile.js

...
        connect: {
            livereload: {
                port: 35728, // not working
                options: {
                    base: "./",
                    port: 9001,
                    middleware: function (connect, options) {
                        return [lrSnippet, mountFolder(connect, options.base)];
                    }
                }
            }
        }
...

check please
:)
